### PR TITLE
Update ci workflows to use newer version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   test:
-    uses: fastify/workflows/.github/workflows/plugins-ci.yml@29329a13c391edeae7d2aa401cbf7664ef830393
+    uses: fastify/workflows/.github/workflows/plugins-ci.yml@v4.1.0
     with:
       license-check: true
       lint: true

--- a/.github/workflows/package-manager-ci.yml
+++ b/.github/workflows/package-manager-ci.yml
@@ -17,4 +17,4 @@ on:
 
 jobs:
   test:
-    uses: fastify/workflows/.github/workflows/plugins-ci-package-manager.yml@29329a13c391edeae7d2aa401cbf7664ef830393
+    uses: fastify/workflows/.github/workflows/plugins-ci-package-manager.yml@v4.1.0


### PR DESCRIPTION
Update to newer workflows that support the Blue Oak license.

This relates to https://github.com/fastify/fast-content-type-parse/issues/22, but I don't think it fixes it.  This still uses a specific pinned version instead of an always moving tag like `v4`.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
