### PR TITLE
Update to tap 18

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,3 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-    ignore:
-      - dependency-name: tap
-        update-types: [ "version-update:semver-major" ]

--- a/.gitignore
+++ b/.gitignore
@@ -138,9 +138,6 @@ dist
 # macOS files
 .DS_Store
 
-# Clinic
-.clinic
-
 # lock files
 bun.lockb
 package-lock.json
@@ -150,3 +147,6 @@ yarn.lock
 # editor files
 .vscode
 .idea
+
+# tap files
+.tap/

--- a/package.json
+++ b/package.json
@@ -24,13 +24,13 @@
     "url": "https://github.com/fastify/fast-content-type-parse.git"
   },
   "devDependencies": {
-    "@fastify/pre-commit": "^2.0.2",
+    "@fastify/pre-commit": "^2.1.0",
     "benchmark": "^2.1.4",
     "busboy": "^1.6.0",
     "content-type": "^1.0.4",
     "standard": "^17.0.0",
-    "tap": "16.3.9",
-    "tsd": "^0.29.0"
+    "tap": "^18.7.1",
+    "tsd": "^0.30.7"
   },
   "pre-commit": [
     "lint",


### PR DESCRIPTION
Ref https://github.com/fastify/fastify/issues/5116.

Might require https://github.com/fastify/fast-content-type-parse/pull/28 to be merged first due to it containing CI changes for Blue Oak licenses included in the Tap 18 update.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
