### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "benchmark": "^2.1.4",
     "busboy": "^1.6.0",
     "content-type": "^1.0.4",
+    "eslint": "^9.17.0",
     "neostandard": "^0.12.0",
     "tap": "^19.2.5",
     "tsd": "^0.31.0"


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.