### PR TITLE
ci: drop node16 and 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,4 +20,3 @@ jobs:
     with:
       license-check: true
       lint: true
-      node-versions: '["16", "18", "20", "22"]'


### PR DESCRIPTION
This line was introduced at: https://github.com/fastify/fast-content-type-parse/pull/31

I think this is a leftover from v1.
How do we want to ship this change?

cc @Uzlopak 